### PR TITLE
refactor: change session to Identifier

### DIFF
--- a/errno/default.go
+++ b/errno/default.go
@@ -23,7 +23,7 @@ var (
 	ServiceError             = NewErrNo(ServiceErrorCode, "service is unable to start successfully")
 	ServiceInternalError     = NewErrNo(ServiceErrorCode, "service Internal Error")
 	ParamError               = NewErrNo(ParamErrorCode, "parameter error")
-	AuthorizationFailedError = NewErrNo(AuthorizationFailedErrCode, "suthorization failed")
+	AuthorizationFailedError = NewErrNo(AuthorizationFailedErrCode, "authorization failed")
 
 	// User
 	AccountConflictError  = NewErrNo(AuthorizationFailedErrCode, "account conflict")

--- a/errno/default.go
+++ b/errno/default.go
@@ -26,11 +26,11 @@ var (
 	AuthorizationFailedError = NewErrNo(AuthorizationFailedErrCode, "authorization failed")
 
 	// User
-	AccountConflictError  = NewErrNo(AuthorizationFailedErrCode, "account conflict")
-	SessionExpiredError   = NewErrNo(AuthorizationFailedErrCode, "session expired")
-	LoginCheckFailedError = NewErrNo(AuthorizationFailedErrCode, "login check failed")
-	SSOLoginFailedError   = NewErrNo(AuthorizationFailedErrCode, "sso login failed")
-	GetSessionFailedError = NewErrNo(AuthorizationFailedErrCode, "get session failed")
+	AccountConflictError     = NewErrNo(AuthorizationFailedErrCode, "account conflict")
+	IdentifierExpiredError   = NewErrNo(AuthorizationFailedErrCode, "session expired")
+	LoginCheckFailedError    = NewErrNo(AuthorizationFailedErrCode, "login check failed")
+	SSOLoginFailedError      = NewErrNo(AuthorizationFailedErrCode, "sso login failed")
+	GetIdentifierFailedError = NewErrNo(AuthorizationFailedErrCode, "get session failed")
 
 	// HTTP
 	HTTPQueryError = NewErrNo(HTTPQueryErrorCode, "HTTP query failed")

--- a/jwch.go
+++ b/jwch.go
@@ -79,7 +79,7 @@ func (s *Student) NewRequest() *resty.Request {
 func (s *Student) GetWithIdentifier(url string) (*html.Node, error) {
 	resp, err := s.NewRequest().SetHeader("Referer", constants.JwchReferer).SetQueryParam("id", s.Identifier).Get(url)
 	if err != nil {
-		return nil, errno.HTTPQueryError.WithErr(err)
+		return nil, errno.SessionExpiredError.WithErr(err)
 	}
 
 	// 会话过期 TODO: 判断条件有点简陋
@@ -97,7 +97,7 @@ func (s *Student) PostWithIdentifier(url string, formData map[string]string) (*h
 	s.NewRequest().EnableTrace()
 
 	if err != nil {
-		return nil, errno.HTTPQueryError.WithErr(err)
+		return nil, errno.SessionExpiredError.WithErr(err)
 	}
 
 	// Identifier缺失 TODO: 判断条件有点简陋

--- a/jwch.go
+++ b/jwch.go
@@ -51,7 +51,7 @@ func (s *Student) WithLoginData(identifier string, cookies []*http.Cookie) *Stud
 	return s
 }
 
-// 携带账号密码，这部分考虑整合到Login中，因为实际上我们不需要这个东西
+// WithUser 携带账号密码，这部分考虑整合到Login中，因为实际上我们不需要这个东西
 func (s *Student) WithUser(id, password string) *Student {
 	s.ID = id
 	s.Password = password
@@ -79,36 +79,36 @@ func (s *Student) NewRequest() *resty.Request {
 func (s *Student) GetWithIdentifier(url string) (*html.Node, error) {
 	resp, err := s.NewRequest().SetHeader("Referer", constants.JwchReferer).SetQueryParam("id", s.Identifier).Get(url)
 	if err != nil {
-		return nil, errno.SessionExpiredError.WithErr(err)
+		return nil, errno.IdentifierExpiredError.WithErr(err)
 	}
 
 	// 会话过期 TODO: 判断条件有点简陋
 	if strings.Contains(string(resp.Body()), "重新登录") {
-		return nil, errno.SessionExpiredError
+		return nil, errno.IdentifierExpiredError
 	}
 
 	return htmlquery.Parse(bytes.NewReader(resp.Body()))
 }
 
-// PostWithSession returns parse tree for the resp of the request.
+// PostWithIdentifier returns parse tree for the resp of the request.
 func (s *Student) PostWithIdentifier(url string, formData map[string]string) (*html.Node, error) {
 	resp, err := s.NewRequest().SetHeader("Referer", constants.JwchReferer).SetQueryParam("id", s.Identifier).SetFormData(formData).Post(url)
 
 	s.NewRequest().EnableTrace()
 
 	if err != nil {
-		return nil, errno.SessionExpiredError.WithErr(err)
+		return nil, errno.IdentifierExpiredError.WithErr(err)
 	}
 
 	// Identifier缺失 TODO: 判断条件有点简陋
 	if strings.Contains(string(resp.Body()), "处理URL失败") {
-		return nil, errno.SessionExpiredError
+		return nil, errno.IdentifierExpiredError
 	}
 
 	return htmlquery.Parse(strings.NewReader(strings.TrimSpace(string(resp.Body()))))
 }
 
-// 获取验证码
+// GetValidateCode 获取验证码
 func GetValidateCode(image string) (string, error) {
 	// 请求西二服务器，自动识别验证码
 	code := verifyCodeResponse{}

--- a/jwch_test.go
+++ b/jwch_test.go
@@ -32,8 +32,8 @@ var (
 )
 
 var (
-	islogin bool     = false
-	stu     *Student = NewStudent().WithUser(username, password)
+	islogin = false
+	stu     = NewStudent().WithUser(username, password)
 )
 
 func login() error {

--- a/user.go
+++ b/user.go
@@ -39,7 +39,7 @@ type verifyCodeResponse struct {
 	Message string `json:"message"`
 }
 
-// 模拟教务处登录/刷新Session
+// Login 模拟教务处登录/刷新Session
 func (s *Student) Login() error {
 	// 清除cookie
 	s.ClearLoginData()
@@ -127,13 +127,13 @@ func (s *Student) Login() error {
 
 	// 这里是err == nil 因为禁止了重定向，正常登录是会出现异常的
 	if err == nil {
-		return errno.GetSessionFailedError
+		return errno.GetIdentifierFailedError
 	}
 
 	data := regexp.MustCompile(`id=(.*?)&`).FindStringSubmatch(err.Error())
 
 	if len(data) < 1 {
-		return errno.GetSessionFailedError
+		return errno.GetIdentifierFailedError
 	}
 
 	s.SetIdentifier(data[1])
@@ -141,7 +141,7 @@ func (s *Student) Login() error {
 	return nil
 }
 
-// 方面服务端进行测试设置的接口
+// GetIdentifierAndCookies 方面服务端进行测试设置的接口
 func (s *Student) GetIdentifierAndCookies() (string, []*http.Cookie, error) {
 	err := s.CheckSession()
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *Student) CheckSession() error {
 	res := htmlquery.FindOne(resp, `//*[@id="ContentPlaceHolder1_LB_xh"]`)
 
 	if res == nil {
-		return errno.SessionExpiredError.WithErr(err)
+		return errno.IdentifierExpiredError.WithErr(err)
 	}
 
 	if htmlquery.OutputHTML(res, false) != s.ID {
@@ -177,7 +177,7 @@ func (s *Student) CheckSession() error {
 	return nil
 }
 
-// 获取学生个人信息
+// GetInfo 获取学生个人信息
 func (s *Student) GetInfo() (resp *StudentDetail, err error) {
 	res, err := s.GetWithIdentifier(constants.UserInfoURL)
 	if err != nil {


### PR DESCRIPTION
说明：
errno 中将id+cookie 描述 为session 是不严谨的，有误导性，改为Identifier
统一 GetWithIdentifier   PostWithIdentifier 的错误返回为 IdentifierExpiredError 
规范了一些方法的注释