### PR TITLE
fix: return nil if examroom is empty

### DIFF
--- a/room.go
+++ b/room.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jwch
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/antchfx/htmlquery"
@@ -282,7 +281,7 @@ func parseExamRoom(doc *html.Node) ([]*ExamRoomInfo, error) {
 	var examInfos []*ExamRoomInfo
 	sel := htmlquery.FindOne(doc, "//*[@id=\"ContentPlaceHolder1_DataList_xxk\"]")
 	if sel == nil {
-		return nil, fmt.Errorf("未查询到考试信息")
+		return nil, nil
 	}
 	rows := htmlquery.Find(sel, ".//tr[@onmouseover]")
 	for _, row := range rows {


### PR DESCRIPTION
当查询的考场教室为空时不返回错误